### PR TITLE
FIX potential detrimental tf api usage

### DIFF
--- a/GAN/AC-GAN/train.py
+++ b/GAN/AC-GAN/train.py
@@ -55,7 +55,7 @@ y_disc = tf.concat(axis=0, values=[y, y * 0])
 #
 
 # get random class number
-if(int(tf.__version__.split(".")[1])<13): ### tf version < 1.13 
+if(int(tf.__version__.split(".")[1])<13 and int(tf.__version__.split(".")[0])<2): ### tf version < 1.13 
     z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
 else: ### tf versioin >= 1.13
     z_cat = tf.random.categorical(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)

--- a/GAN/AC-GAN/train.py
+++ b/GAN/AC-GAN/train.py
@@ -55,7 +55,11 @@ y_disc = tf.concat(axis=0, values=[y, y * 0])
 #
 
 # get random class number
-z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+if(int(tf.__version__.split(".")[1])<13): ### tf version < 1.13 
+    z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+else: ### tf versioin >= 1.13
+    z_cat = tf.random.categorical(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+ 
 z_cat = tf.squeeze(z_cat, -1)
 z_cat = tf.cast(z_cat, tf.int32)
 

--- a/GAN/AC-GAN/train.py
+++ b/GAN/AC-GAN/train.py
@@ -12,8 +12,7 @@ import os
 import sys
 
 
-_logger = tf.logging._logger
-_logger.setLevel(0)
+tf.logging.set_verbosity(0)
 
 
 #

--- a/GAN/Info-GAN/train.py
+++ b/GAN/Info-GAN/train.py
@@ -55,7 +55,11 @@ y_disc = tf.concat(axis=0, values=[y, y * 0])
 #
 
 # get random class number
-z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+if(int(tf.__version__.split(".")[1])<13): ### tf version < 1.13 
+    z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+else: ### tf version >= 1.13
+    z_cat = tf.random.categorical(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
+ 
 z_cat = tf.squeeze(z_cat, -1)
 z_cat = tf.cast(z_cat, tf.int32)
 

--- a/GAN/Info-GAN/train.py
+++ b/GAN/Info-GAN/train.py
@@ -55,7 +55,7 @@ y_disc = tf.concat(axis=0, values=[y, y * 0])
 #
 
 # get random class number
-if(int(tf.__version__.split(".")[1])<13): ### tf version < 1.13 
+if(int(tf.__version__.split(".")[1])<13 and int(tf.__version__.split(".")[0])<2): ### tf version < 1.13 
     z_cat = tf.multinomial(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)
 else: ### tf version >= 1.13
     z_cat = tf.random.categorical(tf.ones((batch_size, cat_dim), dtype=tf.float32) / cat_dim, 1)

--- a/GAN/Info-GAN/train.py
+++ b/GAN/Info-GAN/train.py
@@ -12,8 +12,7 @@ import os
 import sys
 
 
-_logger = tf.logging._logger
-_logger.setLevel(0)
+tf.logging.set_verbosity(0)
 
 
 #


### PR DESCRIPTION
Dear developers,

When I use your project, I found some possible detrimental TensorFlow API use in your code.

As shown in my pull request: `tf.multinomial` has been deprecated since tf v1.13.0 and **removed in tf 2.0.0-alpha**. It's better to replace it with `tf.random.categorical`. Otherwise, crash might happens for users who use the newest version of TensorFlow.
@soloice @burness 
Hope you could take my advice and look forward to your reply! 😃 
